### PR TITLE
Fix a process leak.

### DIFF
--- a/ampoule/pool.py
+++ b/ampoule/pool.py
@@ -134,10 +134,9 @@ class ProcessPool(object):
         """
         Adds the newly created child process to the pool.
         """
-        def restart(child, reason):
-            log.msg("FATAL: Restarting after %s" % (reason,))
+        def ohno(child, reason):
+            log.msg("FATAL: Processe exited %s" % (reason,))
             self._pruneProcess(child)
-            return self.startAWorker()
 
         def dieGently(data, child):
             log.msg("STOPPING: '%s'" % (data,))
@@ -146,7 +145,7 @@ class ProcessPool(object):
         self.processes.add(child)
         self.ready.add(child)
         finished.addCallback(dieGently, child
-               ).addErrback(lambda reason: restart(child, reason))
+               ).addErrback(lambda reason: ohno(child, reason))
         self._finishCallbacks[child] = finished
         self._lastUsage[child] = now()
         self._calls[child] = 0
@@ -337,13 +336,6 @@ class ProcessPool(object):
             # Does this even make sense to you?
             ).addErrback(lambda reason: reason.trap(error.ProcessTerminated))
         return self._finishCallbacks[child]
-
-    def _startSomeWorkers(self):
-        """
-        Start a bunch of workers until we reach the max number of them.
-        """
-        if len(self.processes) < self.max:
-            self.startAWorker()
 
     def adjustPoolSize(self, min=None, max=None):
         """

--- a/ampoule/pool.py
+++ b/ampoule/pool.py
@@ -134,8 +134,8 @@ class ProcessPool(object):
         """
         Adds the newly created child process to the pool.
         """
-        def ohno(child, reason):
-            log.msg("FATAL: Processe exited %s" % (reason,))
+        def fatal(reason, child):
+            log.msg("FATAL: Process exited %s" % (reason,))
             self._pruneProcess(child)
 
         def dieGently(data, child):
@@ -145,7 +145,7 @@ class ProcessPool(object):
         self.processes.add(child)
         self.ready.add(child)
         finished.addCallback(dieGently, child
-               ).addErrback(lambda reason: ohno(child, reason))
+               ).addErrback(fatal, child)
         self._finishCallbacks[child] = finished
         self._lastUsage[child] = now()
         self._calls[child] = 0


### PR DESCRIPTION
When a process exits non-zero ampoule tries to immediately replace it,
this is a problem if the process exits non-zero when recycling because
ampoule also tries to immediately replace the recycled process.

`startWorker` adds a callback that tries to replace the process.
and recycling calls `stopAWorker` and adds a callback that tries to start
a new process.

In the case where `Shutdown` causes a non-zero exit code this caused
two `startAWorker` invocations for every recycled process.