### PR TITLE
Don't return an already-dead child to the ready pool

### DIFF
--- a/ampoule/pool.py
+++ b/ampoule/pool.py
@@ -243,12 +243,12 @@ class ProcessPool(object):
             cancelCall(deadlineCall)
             self.busy.discard(child)
 
-            already_dead = (
+            alreadyDead = (
                 is_error and
                 result.check(error.ProcessTerminated)
             )
 
-            if not (die or already_dead):
+            if not (die or alreadyDead):
                 # we are not marked to be removed, so add us back to
                 # the ready set and let's see if there's some catching
                 # up to do

--- a/ampoule/pool.py
+++ b/ampoule/pool.py
@@ -11,6 +11,7 @@ pop = heapq.heappop
 
 from twisted import logger
 from twisted.internet import defer, task, error
+from twisted.python.failure import Failure
 
 from ampoule import commands, main
 
@@ -241,7 +242,13 @@ class ProcessPool(object):
             cancelCall(timeoutCall)
             cancelCall(deadlineCall)
             self.busy.discard(child)
-            if not die:
+
+            already_dead = (
+                is_error and
+                result.check(error.ProcessTerminated)
+            )
+
+            if not (die or already_dead):
                 # we are not marked to be removed, so add us back to
                 # the ready set and let's see if there's some catching
                 # up to do

--- a/ampoule/test/test_process.py
+++ b/ampoule/test/test_process.py
@@ -122,9 +122,9 @@ class HangForever(amp.Command):
     pass
 
 class TimingOutChild(child.AMPChild):
-    def hang_forever(self):
+    def hangForever(self):
         return defer.Deferred()
-    HangForever.responder(hang_forever)
+    HangForever.responder(hangForever)
 
     def ping(self, data):
         return {'response': data}

--- a/ampoule/test/test_process.py
+++ b/ampoule/test/test_process.py
@@ -917,6 +917,10 @@ class TestProcessPool(unittest.TestCase):
             ).addCallback(lambda _: pp.stop())
 
     def test_processRestartAfterTimeout(self):
+        """
+        Test that a call that times out doesn't cause all subsequent requests
+        to fail
+        """
         pp = pool.ProcessPool(TimingOutChild, min=1, max=1, timeout=1)
 
         def _work(_):


### PR DESCRIPTION
A single-worker pool that times out will fail all subsequent tasks currently in
queue with `errors.ProcessTerminated`.

The sequence of events is this:
 - `_returned` is called with `errors.ProcessTerminated`, but `die=False`
 - The dead child is returned to self.ready
 - `self._catchUp` schedules the next task on the dead child
 - Repeat

To avoid that, we should avoid returning the already-dead worker to the pool,
and just call `stopAWorker(child)` instead.