### PR TITLE
Update NEWS.txt for 19.6.0 and 19.12.0

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,3 +1,14 @@
+Ampoule 19.12.0 (2019-12-21)
+============================
+
+  - Replace all uses of twisted.python.log with twisted.logger.
+  - Don't return an already-dead worker to the ready pool.
+
+Ampoule 19.6.0 (2019-06-18)
+===========================
+
+  - Fix a process leak when a process exits non-zero on recycling.
+
 Ampoule 0.3.1 (2017-12-10)
 ==========================
 


### PR DESCRIPTION
NEWS entries are really handy for people just wanting a quick idea of
what's changed when upgrading dependencies.  In exactly such a
situation, I figured I might as well write down what I'd gleaned from
going through the git log so that other people can use it.