### PR TITLE
Remove "optimize" from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[install]
-optimize = 1
-
 [aliases]
 release = egg_info -RDb ''
 


### PR DESCRIPTION
This setting seems unusual these days, and as far as I know ampoule
doesn't have any of the kind of tight loops where it might make a
significant difference.

Optimization also has some weird effects in conjunction with universal
wheels.  A "universal" ampoule wheel built with optimization on Python 2
will produce a wheel containing `ampoule/*.pyo` files, while one built on
Python 3 will produce a wheel containing `ampoule/__pycache__/*.opt-1.pyc`
files.  If you install the one built on Python 2 in a Python 3
virtualenv, then things will nominally appear to work, but if you then
try to use virtualenv-tools3 to relocate the virtualenv you'll get
"ValueError: bad marshal data (unknown type code)" when it encounters
those files.  This sort of thing seems rather against the spirit of
universal wheels.

https://github.com/jwodder/check-wheel-contents fails if wheels contain
.pyc/.pyo files, and its documentation says: "Solution: Remove this
setting. It's only useful when using setup.py install anyway, which is
deprecated."  Therefore, do so.