### PR TITLE
Fix `install_requires` for use with pip-tools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ Distutils/Setuptools installer for AMPoule.
 
 from setuptools import setup
 
-install_requires = ["Twisted>=17[tls]"]
+install_requires = ["Twisted[tls]>=17"]
 
 description = """A process pool built on Twisted and AMP."""
 long_description = open('README.md').read()


### PR DESCRIPTION
pip-tools errors out with the current `install_requires`:

```
Traceback (most recent call last):
  File "/Users/andyfreeland/test-project/.tox/pip-compile/bin/pip-compile", line 8, in <module>
    sys.exit(cli())
  File "/Users/andyfreeland/test-project/.tox/pip-compile/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/andyfreeland/test-project/.tox/pip-compile/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/andyfreeland/test-project/.tox/pip-compile/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/andyfreeland/test-project/.tox/pip-compile/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/andyfreeland/test-project/.tox/pip-compile/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/andyfreeland/test-project/.tox/pip-compile/lib/python3.8/site-packages/piptools/scripts/compile.py", line 466, in cli
    results = resolver.resolve(max_rounds=max_rounds)
  File "/Users/andyfreeland/test-project/.tox/pip-compile/lib/python3.8/site-packages/piptools/resolver.py", line 175, in resolve
    has_changed, best_matches = self._resolve_one_round()
  File "/Users/andyfreeland/test-project/.tox/pip-compile/lib/python3.8/site-packages/piptools/resolver.py", line 319, in _resolve_one_round
    their_constraints.extend(self._iter_dependencies(best_match))
  File "/Users/andyfreeland/test-project/.tox/pip-compile/lib/python3.8/site-packages/piptools/resolver.py", line 440, in _iter_dependencies
    yield install_req_from_line(
  File "/Users/andyfreeland/test-project/.tox/pip-compile/lib/python3.8/site-packages/pip/_internal/req/constructors.py", line 366, in install_req_from_line
    parts = parse_req_from_line(name, line_source)
  File "/Users/andyfreeland/test-project/.tox/pip-compile/lib/python3.8/site-packages/pip/_internal/req/constructors.py", line 343, in parse_req_from_line
    req: Optional[Requirement] = _parse_req_string(req_as_string)
  File "/Users/andyfreeland/test-project/.tox/pip-compile/lib/python3.8/site-packages/pip/_internal/req/constructors.py", line 339, in _parse_req_string
    raise InstallationError(msg)
pip._internal.exceptions.InstallationError: Extras after version '>=17[tls]'.
```
