### PR TITLE
Switch from `imp` to `importlib.util` for Python 3.12 compatibility

### DIFF
--- a/ampoule/main.py
+++ b/ampoule/main.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import imp
+import importlib.util
 import itertools
 
 from zope.interface import implementer
@@ -285,7 +285,7 @@ def spawnProcess(processProtocol, bootstrap, args=(), env={},
 
     pythonpath = []
     for pkg in packages:
-        p = os.path.split(imp.find_module(pkg)[1])[0]
+        p = os.path.split(importlib.util.find_spec(pkg).origin)[0]
         if p.startswith(os.path.join(sys.prefix, 'lib')):
             continue
         pythonpath.append(p)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Topic :: System',


### PR DESCRIPTION
Note that this requires dropping 2.7 compatibility.
